### PR TITLE
fix(toPem): function returns buffer instead of string value

### DIFF
--- a/source/crypto_utils.ts
+++ b/source/crypto_utils.ts
@@ -61,7 +61,7 @@ export function toPem(raw_key: Buffer | string, pem: string): string {
     assert(typeof pem === "string");
     let pemType = identifyPemType(raw_key);
     if (pemType) {
-        return raw_key as string;
+        return raw_key instanceof Buffer ?  raw_key.toString("utf8") : raw_key;
     } else {
         pemType = pem;
         assert(["CERTIFICATE REQUEST", "CERTIFICATE", "RSA PRIVATE KEY", "PUBLIC KEY", "X509 CRL"].indexOf(pemType) >= 0);

--- a/test/test_crypto_utils.ts
+++ b/test/test_crypto_utils.ts
@@ -82,6 +82,18 @@ describe("Crypto utils", function () {
 
         digest.length.should.eql(20); // SHA1 should condensed to 160 bits
     });
+
+    it("toPem should return a string if provided certificate is a buffer containing a PEM string", () => {
+        const certificate = fs.readFileSync(path.join(__dirname, "./fixtures/certs/cert1.pem"), null);
+        const pemCertificate = toPem(certificate, "CERTIFICATE");
+        pemCertificate.should.be.type('string');
+    });
+
+    it("toPem should return a certificate directly if provided certificate is PEM string", () => {
+        const certificate = fs.readFileSync(path.join(__dirname, "./fixtures/certs/cert1.pem"), 'ascii');
+        const pemCertificate = toPem(certificate, "CERTIFICATE");
+        pemCertificate.should.eql(certificate);
+    });
 });
 
 describe("exploreCertificate", () => {


### PR DESCRIPTION
According to the function's signature, it always returns a string
value. However, if the caller passed a Buffer containing a valid PEM
string, it returns the Buffer directly.