### PR TITLE
ci: move actions to node24 runtimes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,14 +20,14 @@ jobs:
         runs-on: ${{ matrix.os }}
 
         steps:
-            - uses: actions/checkout@v4.2.2
+            - uses: actions/checkout@v7
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4.1.0
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ matrix.node-version }}
             - run: npm install
             - name: Cache dependencies
-              uses: actions/cache@v4.2.0
+              uses: actions/cache@v6
               with:
                   key: ${{ runner.os }}-node-modules-${{ github.sha }}
                   path: node_modules
@@ -40,19 +40,19 @@ jobs:
                 os: [ubuntu-latest]
         runs-on: ${{ matrix.os }}
         steps:
-            - uses: actions/checkout@v4.2.2
-            - uses: actions/setup-node@v4.1.0
+            - uses: actions/checkout@v7
+            - uses: actions/setup-node@v7
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Cache dependencies
-              uses: actions/cache@v4.2.0
+              uses: actions/cache@v6
               with:
                   key: ${{ runner.os }}-node-modules-${{ github.sha }}
                   path: node_modules
             - run: npm install
             - run: npm run build
             - name: Cache build artifacts
-              uses: actions/cache@v4.2.0
+              uses: actions/cache@v6
               with:
                   enableCrossOsArchive: true
                   key: dist-${{ github.sha }}
@@ -68,21 +68,21 @@ jobs:
         needs: build
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4.2.2
+            - uses: actions/checkout@v7
 
             - name: Use Node.js
-              uses: actions/setup-node@v4.1.0
+              uses: actions/setup-node@v7
               with:
                   node-version: 24.x
 
             - name: Restore dependencies
-              uses: actions/cache@v4.2.0
+              uses: actions/cache@v6
               with:
                   key: ${{ runner.os }}-node-modules-${{ github.sha }}
                   path: node_modules
 
             - name: Restore build artifacts
-              uses: actions/cache@v4.2.0
+              uses: actions/cache@v6
               with:
                   enableCrossOsArchive: true
                   key: dist-${{ github.sha }}
@@ -115,21 +115,21 @@ jobs:
         steps:
             # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
             - name: checkout
-              uses: actions/checkout@v4.2.2
+              uses: actions/checkout@v7
 
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4.1.0
+              uses: actions/setup-node@v7
               with:
                   node-version: ${{ matrix.node-version }}
 
             - name: Restore dependencies
-              uses: actions/cache@v4.2.0
+              uses: actions/cache@v6
               with:
                   key: ${{ runner.os }}-node-modules-${{ github.sha }}
                   path: node_modules
 
             - name: Restore build artifacts
-              uses: actions/cache@v4.2.0
+              uses: actions/cache@v6
               with:
                   enableCrossOsArchive: true
                   key: dist-${{ github.sha }}
@@ -152,10 +152,10 @@ jobs:
     #     runs-on: ${{ matrix.os }}
     #     steps:
     #         - name: checkout
-    #           uses: actions/checkout@v4.2.2
+    #           uses: actions/checkout@v7
 
     #         - name: Use Node.js ${{ matrix.node-version }}
-    #           uses: actions/setup-node@v4.1.0
+    #           uses: actions/setup-node@v7
     #           with:
     #               node-version: ${{ matrix.node-version }}
 
@@ -163,13 +163,13 @@ jobs:
     #           run: node --version
 
     #         - name: Restore dependencies
-    #           uses: actions/cache@v4.2.0
+    #           uses: actions/cache@v6
     #           with:
     #               key: ${{ runner.os }}-node-modules-${{ github.sha }}
     #               path: node_modules
 
     #         - name: Restore build artifacts
-    #           uses: actions/cache@v4.2.0
+    #           uses: actions/cache@v6
     #           with:
     #               enableCrossOsArchive: true
     #               key: dist-${{ github.sha }}
@@ -197,10 +197,10 @@ jobs:
     #     runs-on: ${{ matrix.os }}
     #     steps:
     #         - name: checkout
-    #           uses: actions/checkout@v4.2.2
+    #           uses: actions/checkout@v7
 
     #         - name: Use Node.js ${{ matrix.node-version }}
-    #           uses: actions/setup-node@v4.1.0
+    #           uses: actions/setup-node@v7
     #           with:
     #               node-version: ${{ matrix.node-version }}
 
@@ -208,13 +208,13 @@ jobs:
     #           run: node --version
 
     #         - name: Restore dependencies
-    #           uses: actions/cache@v4.2.0
+    #           uses: actions/cache@v6
     #           with:
     #               key: ${{ runner.os }}-node-modules-${{ github.sha }}
     #               path: node_modules
 
     #         - name: Restore build artifacts
-    #           uses: actions/cache@v4.2.0
+    #           uses: actions/cache@v6
     #           with:
     #               enableCrossOsArchive: true
     #               key: dist-${{ github.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Why

GitHub Actions warns:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced
> to run on Node.js 24: actions/checkout@v4, actions/setup-node@v4

This is the **action's own JS runtime** (`using: node20` in its `action.yml`) — not the
runner image, and not the Node version under test. So the fix is newer action majors, and
the test matrix is untouched.

| | was | now | runtime |
|---|---|---|---|
| `actions/checkout` | v4.2.2 / v4 | **v7** | node24 |
| `actions/setup-node` | v4.1.0 / v4 | **v7** | node24 |
| `actions/cache` | v4.2.0 | **v6** | node24 |

## Breaking changes checked, neither applies

- **setup-node v5** begins caching automatically when `package.json` declares a
  `packageManager` field. This repo has none, so nothing starts caching implicitly
  alongside the existing `actions/cache` steps.
- **setup-node v7** dropped its dummy `NODE_AUTH_TOKEN` export. `publish.yml` sets the
  token explicitly via `npm set //registry.npmjs.org/:_authToken` and never relied on it.

## Confidence

The identical bump is already green on `node-opcua-pki`, including a job that runs inside
a `node:N-alpine` container — the harder case, since the runner must inject a
musl-compatible node24 there. This repo has no container job, so it's the easier target.

Workflow-only change: no source, dependency or published-package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
