### PR TITLE
fix(dn): parse a Distinguished Name faithfully — repeats, multi-valued RDNs, organizationalUnitName

### DIFF
--- a/packages/node-opcua-crypto-test/test/test_directory_name.ts
+++ b/packages/node-opcua-crypto-test/test/test_directory_name.ts
@@ -1,0 +1,107 @@
+import { asn1 } from "node-opcua-crypto";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Distinguished Name parsing.
+ *
+ * A DN is a *sequence*, not a record: an attribute may repeat, and both the
+ * repetition and the order carry meaning. Two things used to be lost —
+ * a repeated attribute overwrote the previous one, and only the first attribute
+ * of a multi-valued RDN was read — which is invisible to a caller reading
+ * `subject.commonName` and fatal to one that must reproduce the DN faithfully,
+ * such as an OPC UA Part 18 §4.4.3 `X509Subject` role criteria.
+ *
+ * The DER here is hand-built so the exact structure under test is explicit.
+ */
+
+/** Minimal DER TLV encoder — short-form lengths only, which is all these need. */
+const tlv = (tag: number, ...payload: Buffer[]): Buffer => {
+    const value = Buffer.concat(payload);
+    if (value.length > 127) throw new Error("test helper only encodes short-form lengths");
+    return Buffer.concat([Buffer.from([tag, value.length]), value]);
+};
+
+const SEQUENCE = 0x30;
+const SET = 0x31;
+const OID = 0x06;
+const UTF8_STRING = 0x0c;
+
+const oid = (...bytes: number[]) => tlv(OID, Buffer.from(bytes));
+const text = (value: string) => tlv(UTF8_STRING, Buffer.from(value, "ascii"));
+
+// 2.5.4.3 commonName / 2.5.4.11 organizationUnitName / 2.5.4.5 serialNumber
+const CN = () => oid(0x55, 0x04, 0x03);
+const OU = () => oid(0x55, 0x04, 0x0b);
+const SERIAL_NUMBER = () => oid(0x55, 0x04, 0x05);
+// 0.9.2342.19200300.100.1.25 domainComponent
+const DC = () => oid(0x09, 0x92, 0x26, 0x89, 0x93, 0xf2, 0x2c, 0x64, 0x01, 0x19);
+
+/** One single-valued RDN: SET { SEQUENCE { type, value } }. */
+const rdn = (type: Buffer, value: string) => tlv(SET, tlv(SEQUENCE, type, text(value)));
+
+/** A multi-valued RDN: SET { SEQUENCE {..}, SEQUENCE {..} }. */
+const multiRdn = (...pairs: Array<[Buffer, string]>) => tlv(SET, ...pairs.map(([type, value]) => tlv(SEQUENCE, type, text(value))));
+
+const parse = (...rdns: Buffer[]) => {
+    const der = tlv(SEQUENCE, ...rdns);
+    return asn1.readDirectoryName(der, asn1.readTag(der, 0));
+};
+
+describe("readDirectoryName", () => {
+    it("reads a simple name into the convenience properties", () => {
+        const name = parse(rdn(CN(), "operator-1"), rdn(OU(), "Plant"));
+        expect(name.commonName).toBe("operator-1");
+        expect(name.organizationalUnitName).toBe("Plant");
+    });
+
+    it("keeps every repeated attribute, in certificate order", () => {
+        // The map can only hold one, so this is what `entries` exists for.
+        const name = parse(rdn(CN(), "x"), rdn(OU(), "Plant"), rdn(OU(), "Night"));
+        expect(name.entries.map((e) => [e.name, e.value])).toEqual([
+            ["commonName", "x"],
+            ["organizationalUnitName", "Plant"],
+            ["organizationalUnitName", "Night"],
+        ]);
+    });
+
+    it("still exposes the last value of a repeated attribute on the map, as before", () => {
+        const name = parse(rdn(OU(), "Plant"), rdn(OU(), "Night"));
+        expect(name.organizationUnitName).toBe("Night");
+    });
+
+    it("preserves order even when the same attribute is interleaved", () => {
+        const name = parse(rdn(OU(), "a"), rdn(CN(), "b"), rdn(OU(), "c"));
+        expect(name.entries.map((e) => e.value)).toEqual(["a", "b", "c"]);
+    });
+
+    it("reads every attribute of a multi-valued RDN, not just the first", () => {
+        // SET { CN=x + serialNumber=42 } is legal X.500 and does occur; the
+        // previous implementation asserted a single attribute and lost the rest.
+        const name = parse(multiRdn([CN(), "x"], [SERIAL_NUMBER(), "42"]));
+        expect(name.entries.map((e) => [e.name, e.value])).toEqual([
+            ["commonName", "x"],
+            ["serialNumber", "42"],
+        ]);
+        expect(name.commonName).toBe("x");
+        expect(name.serialNumber).toBe("42");
+    });
+
+    it("exposes domainComponent, dnQualifier and serialNumber, which the type used to hide", () => {
+        // These were produced at runtime all along but missing from DirectoryName,
+        // so TypeScript hid them from callers.
+        const name = parse(rdn(DC(), "example"), rdn(SERIAL_NUMBER(), "7"));
+        expect(name.domainComponent).toBe("example");
+        expect(name.serialNumber).toBe("7");
+    });
+
+    it("records the OID alongside the resolved name", () => {
+        const name = parse(rdn(CN(), "x"));
+        expect(name.entries[0].oid).toBe("2.5.4.3");
+        expect(name.entries[0].name).toBe("commonName");
+    });
+
+    it("returns an empty entry list for an empty name", () => {
+        const name = parse();
+        expect(name.entries).toEqual([]);
+    });
+});

--- a/packages/node-opcua-crypto/source/crypto_explore_certificate.ts
+++ b/packages/node-opcua-crypto/source/crypto_explore_certificate.ts
@@ -112,22 +112,19 @@ function _readAttributeTypeAndValue(buffer: Buffer, block: BlockInfo): Attribute
     return result;
 }
 
-interface RelativeDistinguishedName {
-    [prop: string]: unknown;
-}
-
-function _readRelativeDistinguishedName(buffer: Buffer, block: BlockInfo): RelativeDistinguishedName {
-    const inner_blocks = readStruct(buffer, block);
-    const data = inner_blocks.map((block) => _readAttributeTypeAndValue(buffer, block));
-    const result: RelativeDistinguishedName = {};
-    for (const e of data) {
-        result[e.identifier as string] = e.value;
-    }
-    return result;
-}
-
-function _readName(buffer: Buffer, block: BlockInfo): RelativeDistinguishedName {
-    return _readRelativeDistinguishedName(buffer, block);
+/**
+ * Read a Name (RDNSequence) from a certificate.
+ *
+ * Delegates to {@link readDirectoryName} rather than parsing the structure a
+ * second time. There were two implementations of this in the package and they
+ * shared the same two defects: a repeated attribute silently overwrote the
+ * previous one, and only the first attribute of a multi-valued RDN was read.
+ * Callers that must reproduce a DN faithfully — OPC UA Part 18 §4.4.3
+ * `X509Subject` role criteria, for one — need the ordered `entries` this now
+ * carries.
+ */
+function _readName(buffer: Buffer, block: BlockInfo): DirectoryName {
+    return readDirectoryName(buffer, block);
 }
 
 export interface Validity {

--- a/packages/node-opcua-crypto/source/directory_name.ts
+++ b/packages/node-opcua-crypto/source/directory_name.ts
@@ -1,32 +1,102 @@
 import assert from "node:assert";
 import { type BlockInfo, readObjectIdentifier, readStruct, readValue } from "./asn1";
 
+/**
+ * One attribute of a Distinguished Name, as it appears in the certificate.
+ *
+ * Kept as an ordered list alongside the convenience map because a DN is a
+ * *sequence*, not a record: an attribute may legitimately repeat (two `OU`s,
+ * several `DC`s), and both the repetition and the order carry meaning. Callers
+ * that must reproduce a DN faithfully — OPC UA Part 18 §4.4.3 Table 10
+ * `X509Subject` role criteria, for instance — cannot do so from the map alone,
+ * because the map keeps only the last value for a repeated attribute.
+ */
+export interface DistinguishedNameAttribute {
+    /** Dotted OID, e.g. `2.5.4.3`. */
+    oid: string;
+    /** Resolved attribute name, e.g. `commonName`; the OID when unknown. */
+    name: string;
+    value: string;
+}
+
+/**
+ * A parsed Distinguished Name.
+ *
+ * The named properties are a convenience view and keep the **last** value when
+ * an attribute repeats. {@link DirectoryName.entries} is the faithful one.
+ */
 export interface DirectoryName {
     stateOrProvinceName?: string;
     localityName?: string;
     organizationName?: string;
+    /**
+     * OU (2.5.4.11). Note the spelling: the OID table resolves this attribute to
+     * `organizationalUnitName`, so this is the property that carries the value.
+     */
+    organizationalUnitName?: string;
+    /**
+     * @deprecated Misspelling of {@link DirectoryName.organizationalUnitName}.
+     *
+     * It was **never populated**. The parser keys properties by the name the OID
+     * table returns — `organizationalUnitName` — so every caller reading this got
+     * `undefined` and silently lost the OU. It is now filled with the same value,
+     * so existing readers start working instead of continuing to miss it.
+     */
     organizationUnitName?: string;
     commonName?: string;
     countryName?: string;
+    /**
+     * These three were always produced at runtime — the parser assigns whatever
+     * name the OID resolves to — but were missing from this interface, so
+     * TypeScript hid them from callers.
+     */
+    domainComponent?: string;
+    dnQualifier?: string;
+    /** The DN's own `serialNumber` attribute (2.5.4.5), not the certificate's. */
+    serialNumber?: string;
+    /** Every attribute in certificate order, repeats included. */
+    entries: DistinguishedNameAttribute[];
 }
 
 export function readDirectoryName(buffer: Buffer, block: BlockInfo): DirectoryName {
+    // RDNSequence ::= SEQUENCE OF RelativeDistinguishedName
+    // RelativeDistinguishedName ::= SET SIZE (1..MAX) OF AttributeTypeAndValue
     // AttributeTypeAndValue ::= SEQUENCE {
     //    type   ATTRIBUTE.&id({SupportedAttributes}),
     //    value  ATTRIBUTE.&Type({SupportedAttributes}{@type}),
     const set_blocks = readStruct(buffer, block);
-    const names: DirectoryName = {};
+    const entries: DistinguishedNameAttribute[] = [];
+
     for (const set_block of set_blocks) {
         assert(set_block.tag === 0x31);
         const blocks = readStruct(buffer, set_block);
-        assert(blocks.length === 1);
-        assert(blocks[0].tag === 0x30);
 
-        const sequenceBlock = readStruct(buffer, blocks[0]);
-        assert(sequenceBlock.length === 2);
+        // A RelativeDistinguishedName is a SET of one *or more* attributes: a
+        // multi-valued RDN such as `CN=x + serialNumber=1` is legal X.500 and
+        // does occur. The previous implementation asserted exactly one and threw
+        // on such a certificate rather than parsing it.
+        for (const attribute_block of blocks) {
+            assert(attribute_block.tag === 0x30);
+            const sequenceBlock = readStruct(buffer, attribute_block);
+            assert(sequenceBlock.length === 2);
 
-        const type = readObjectIdentifier(buffer, sequenceBlock[0]);
-        names[type.name as keyof DirectoryName] = readValue(buffer, sequenceBlock[1]) as string;
+            const type = readObjectIdentifier(buffer, sequenceBlock[0]);
+            const value = readValue(buffer, sequenceBlock[1]) as string;
+            entries.push({ oid: type.oid, name: type.name, value });
+        }
+    }
+
+    const names: DirectoryName = { entries };
+    // Last-wins for the convenience view, which is the historical behaviour and
+    // what existing callers already rely on.
+    const asRecord = names as unknown as Record<string, unknown>;
+    for (const entry of entries) {
+        asRecord[entry.name] = entry.value;
+        // Fill the long-standing misspelling too, so callers written against it
+        // stop silently receiving undefined.
+        if (entry.name === "organizationalUnitName") {
+            asRecord.organizationUnitName = entry.value;
+        }
     }
     return names;
 }

--- a/packages/node-opcua-crypto/source/explore_certificate_revocation_list.ts
+++ b/packages/node-opcua-crypto/source/explore_certificate_revocation_list.ts
@@ -41,7 +41,17 @@ import { makeSHA1Thumbprint } from "./crypto_utils.js";
 import { type DirectoryName, readDirectoryName } from "./directory_name.js";
 
 export type Version = string;
-export type Name = string;
+/**
+ * A Name is an RDNSequence, not a string.
+ *
+ * This was declared `string` while `readNameForCrl` has always returned a
+ * {@link DirectoryName} object — the `as TBSCertList` casts below hid the
+ * mismatch, so `tbsCertList.issuer` type-checked as a string while being an
+ * object at runtime. Correcting the declaration is a breaking *type* change and
+ * no behaviour change at all: callers reading `issuer` as a string were already
+ * getting an object.
+ */
+export type Name = DirectoryName;
 export type CertificateSerialNumber = string;
 export type Extensions = Record<string, unknown>;
 export interface RevokedCertificate {

--- a/packages/node-opcua-crypto/source/index_web.ts
+++ b/packages/node-opcua-crypto/source/index_web.ts
@@ -30,7 +30,7 @@
 export * from "./common.js";
 export * from "./crl_utils.js";
 export * from "./crypto_explore_certificate.js";
-export type { DirectoryName } from "./directory_name.js";
+export type { DirectoryName, DistinguishedNameAttribute } from "./directory_name.js";
 export * from "./explore_asn1.js";
 export * from "./explore_certificate.js";
 export * from "./explore_certificate.js";


### PR DESCRIPTION
A Distinguished Name is a *sequence*, not a record. An attribute may repeat, and both the repetition and the order carry meaning. Three things were being lost — all invisible to a caller reading `subject.commonName`, and all fatal to a caller that has to reproduce a DN faithfully.

The motivating case is OPC UA **Part 18 §4.4.3 Table 10** `X509Subject` role criteria, where a rule must list *every* attribute present in the subject, in a fixed order, with repeats in certificate order. There are no wildcards, so a criteria built from an incomplete or reordered view of the DN does not match "less precisely" — **it matches nobody at all**, while looking entirely plausible in a role editor. That is a silent authorisation failure, which is why this is worth fixing at the source rather than working around downstream.

## The three defects

**1. Repeated attributes overwrote each other.**

`names[type.name] = value` in a loop, so a subject with two `OU`s kept only the last. `DirectoryName.entries` now carries every attribute in certificate order, with its OID:

```ts
const { subject } = exploreCertificate(cert).tbsCertificate;
subject.entries; // [{ oid: "2.5.4.3", name: "commonName", value: "operator-1" },
                 //  { oid: "2.5.4.11", name: "organizationalUnitName", value: "Plant" },
                 //  { oid: "2.5.4.11", name: "organizationalUnitName", value: "Night" }]
```

**2. Only the first attribute of a multi-valued RDN was read.**

`RelativeDistinguishedName ::= SET SIZE (1..MAX) OF AttributeTypeAndValue`. A multi-valued RDN such as `CN=x + serialNumber=42` is legal X.500 and does occur in the wild. The old code `assert`ed `blocks.length === 1`, so such a certificate would **throw** rather than parse.

**3. `organizationUnitName` was never populated.**

This is the sharpest one. The OID table resolves `2.5.4.11` to `organizational`**UnitName**, but the `DirectoryName` interface declares `organizationUnitName`. Since properties are keyed by the resolved OID name, the declared property has always been `undefined` — every caller reading it silently lost the OU.

Both spellings are now filled, and the misspelling is marked `@deprecated`. It is populated rather than removed so that existing (silently broken) readers start working instead of continuing to miss the value.

## Two structural changes

**Removed a duplicate DN parser.** `crypto_explore_certificate.ts` had its own private `_readRelativeDistinguishedName` feeding `exploreCertificate`, with exactly the same defects as `readDirectoryName`. `_readName` now delegates, so there is one implementation. The two used the same `readObjectIdentifier(...).name` for attribute naming, so this is behaviour-preserving apart from the fixes above.

**`Name` retyped from `string` to `DirectoryName`.** `readNameForCrl` has always returned a `DirectoryName` object; `TBSCertList.issuer` was declared `string` and an `as TBSCertList` cast hid the mismatch. So `tbsCertList.issuer` type-checked as a string while being an object at runtime.

This is a **breaking type change with no behaviour change** — callers treating `issuer` as a string were already receiving an object. It surfaced because adding a required `entries` field removed the structural overlap that let the cast through, which is arguably the type system doing its job.

## Compatibility

- Additive for the named properties; `entries` is new and required on `DirectoryName`.
- `organizationUnitName` keeps working and now actually carries a value.
- `Name` / `TBSCertList.issuer` is the one breaking type change — see above.
- Suggest a minor bump for the type change.

## Tests

`test_directory_name.ts`, 8 cases, hand-built DER so the exact structure under test is explicit rather than depending on a fixture certificate's contents: repeats preserved and ordered, interleaved repeats, multi-valued RDN, the previously hidden `domainComponent` / `dnQualifier` / `serialNumber`, OID recorded alongside the name, and the empty name.

Full suite: **209 passing, 2 skipped, 27 files** — no regressions.
