### PR TITLE
Restrict private key permissions, add opt-in passphrase encryption

### DIFF
--- a/packages/node-opcua-crypto-test/test/test_private_key_passphrase.ts
+++ b/packages/node-opcua-crypto-test/test/test_private_key_passphrase.ts
@@ -1,0 +1,204 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+    coercePEMorDerToPrivateKey,
+    generatePrivateKeyFile,
+    PrivateKeyPassphraseRequiredError,
+    pemToPrivateKey,
+    readPrivateKey,
+    readPrivateKeyAsync,
+    writePrivateKeyFile,
+} from "node-opcua-crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Under NO_CREATE_PRIVATEKEY=1, node:crypto.createPrivateKey is treated as
+// unavailable everywhere in this process, so decrypting an encrypted key is
+// fundamentally impossible — myCreatePrivateKey's fallback path fails closed
+// (see the "NO_CREATE_PRIVATEKEY fallback path" tests below), it cannot
+// succeed. Tests that assert successful decryption are skipped in that mode.
+const canDecryptEncryptedKeys = !process.env.NO_CREATE_PRIVATEKEY;
+
+describe("private key passphrase support", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "node-opcua-crypto-passphrase-"));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it("generatePrivateKeyFile with a passphrase should write an ENCRYPTED PRIVATE KEY PEM", async () => {
+        const filename = path.join(tmpDir, "key.pem");
+        await generatePrivateKeyFile(filename, 2048, { passphrase: "correct horse battery staple" });
+
+        const pem = fs.readFileSync(filename, "utf-8");
+        expect(pem).toContain("-----BEGIN ENCRYPTED PRIVATE KEY-----");
+    });
+
+    it.skipIf(!canDecryptEncryptedKeys)("readPrivateKey should decrypt an encrypted key given the correct passphrase", async () => {
+        const filename = path.join(tmpDir, "key.pem");
+        const passphrase = "correct horse battery staple";
+        await generatePrivateKeyFile(filename, 2048, { passphrase });
+
+        const key = readPrivateKey(filename, passphrase);
+        expect(key.hidden).toBeTruthy();
+    });
+
+    it.skipIf(!canDecryptEncryptedKeys)(
+        "readPrivateKeyAsync should decrypt an encrypted key given the correct passphrase",
+        async () => {
+            const filename = path.join(tmpDir, "key.pem");
+            const passphrase = "correct horse battery staple";
+            await generatePrivateKeyFile(filename, 2048, { passphrase });
+
+            const key = await readPrivateKeyAsync(filename, passphrase);
+            expect(key.hidden).toBeTruthy();
+        },
+    );
+
+    it("readPrivateKey should fail closed (throw PrivateKeyPassphraseRequiredError) when no passphrase is supplied", async () => {
+        const filename = path.join(tmpDir, "key.pem");
+        await generatePrivateKeyFile(filename, 2048, { passphrase: "some passphrase" });
+
+        expect(() => readPrivateKey(filename)).toThrow(PrivateKeyPassphraseRequiredError);
+    });
+
+    it("readPrivateKeyAsync should fail closed (throw PrivateKeyPassphraseRequiredError) when no passphrase is supplied", async () => {
+        const filename = path.join(tmpDir, "key.pem");
+        await generatePrivateKeyFile(filename, 2048, { passphrase: "some passphrase" });
+
+        await expect(readPrivateKeyAsync(filename)).rejects.toThrow(PrivateKeyPassphraseRequiredError);
+    });
+
+    it("readPrivateKey should throw (not silently succeed) when given the wrong passphrase", async () => {
+        const filename = path.join(tmpDir, "key.pem");
+        await generatePrivateKeyFile(filename, 2048, { passphrase: "correct passphrase" });
+
+        expect(() => readPrivateKey(filename, "wrong passphrase")).toThrow();
+    });
+
+    it("readPrivateKey should read a passphrase-configured key with no passphrase supplied at generation time (unencrypted, backward compatible)", async () => {
+        const filename = path.join(tmpDir, "key.pem");
+        await generatePrivateKeyFile(filename, 2048);
+
+        const pem = fs.readFileSync(filename, "utf-8");
+        expect(pem).toContain("-----BEGIN PRIVATE KEY-----");
+        expect(pem).not.toContain("ENCRYPTED");
+
+        const key = readPrivateKey(filename);
+        expect(key.hidden).toBeTruthy();
+    });
+
+    it.skipIf(!canDecryptEncryptedKeys)(
+        "writePrivateKeyFile should round-trip an in-memory PrivateKey through encryption and back",
+        async () => {
+            const plainFilename = path.join(tmpDir, "plain.pem");
+            await generatePrivateKeyFile(plainFilename, 2048);
+            const privateKey = readPrivateKey(plainFilename);
+
+            const encryptedFilename = path.join(tmpDir, "encrypted.pem");
+            const passphrase = "round-trip passphrase";
+            await writePrivateKeyFile(encryptedFilename, privateKey, { passphrase });
+
+            const pem = fs.readFileSync(encryptedFilename, "utf-8");
+            expect(pem).toContain("-----BEGIN ENCRYPTED PRIVATE KEY-----");
+
+            const decrypted = readPrivateKey(encryptedFilename, passphrase);
+            expect(decrypted.hidden).toBeTruthy();
+        },
+    );
+
+    it("writePrivateKeyFile without a passphrase should write an unencrypted PKCS#8 PEM", async () => {
+        const plainFilename = path.join(tmpDir, "plain.pem");
+        await generatePrivateKeyFile(plainFilename, 2048);
+        const privateKey = readPrivateKey(plainFilename);
+
+        const outFilename = path.join(tmpDir, "out.pem");
+        await writePrivateKeyFile(outFilename, privateKey);
+
+        const pem = fs.readFileSync(outFilename, "utf-8");
+        expect(pem).toContain("-----BEGIN PRIVATE KEY-----");
+        expect(pem).not.toContain("ENCRYPTED");
+    });
+
+    describe("coercePEMorDerToPrivateKey (Node path)", () => {
+        it("should fail closed when the PEM is encrypted and no passphrase is supplied", async () => {
+            const filename = path.join(tmpDir, "key.pem");
+            await generatePrivateKeyFile(filename, 2048, { passphrase: "some passphrase" });
+            const pem = fs.readFileSync(filename, "utf-8");
+
+            expect(() => coercePEMorDerToPrivateKey(pem)).toThrow(PrivateKeyPassphraseRequiredError);
+        });
+
+        it("should decrypt when the correct passphrase is supplied", async () => {
+            const filename = path.join(tmpDir, "key.pem");
+            const passphrase = "some passphrase";
+            await generatePrivateKeyFile(filename, 2048, { passphrase });
+            const pem = fs.readFileSync(filename, "utf-8");
+
+            const key = coercePEMorDerToPrivateKey(pem, passphrase);
+            expect(key.hidden).toBeTruthy();
+        });
+
+        it("should be unaffected by the passphrase parameter for unencrypted input", async () => {
+            const filename = path.join(tmpDir, "key.pem");
+            await generatePrivateKeyFile(filename, 2048);
+            const pem = fs.readFileSync(filename, "utf-8");
+
+            const key = coercePEMorDerToPrivateKey(pem);
+            expect(key.hidden).toBeTruthy();
+        });
+    });
+
+    describe("NO_CREATE_PRIVATEKEY fallback path", () => {
+        const originalEnv = process.env.NO_CREATE_PRIVATEKEY;
+
+        afterEach(() => {
+            if (originalEnv === undefined) {
+                delete process.env.NO_CREATE_PRIVATEKEY;
+            } else {
+                process.env.NO_CREATE_PRIVATEKEY = originalEnv;
+            }
+        });
+
+        it("should fail closed rather than silently returning the still-encrypted PEM", async () => {
+            const filename = path.join(tmpDir, "key.pem");
+            await generatePrivateKeyFile(filename, 2048, { passphrase: "some passphrase" });
+
+            process.env.NO_CREATE_PRIVATEKEY = "1";
+            expect(() => readPrivateKey(filename)).toThrow(PrivateKeyPassphraseRequiredError);
+            expect(() => readPrivateKey(filename, "some passphrase")).toThrow(PrivateKeyPassphraseRequiredError);
+        });
+
+        it("should still return unencrypted key PEM text unchanged (pre-existing fallback behavior)", async () => {
+            const filename = path.join(tmpDir, "key.pem");
+            await generatePrivateKeyFile(filename, 2048);
+
+            process.env.NO_CREATE_PRIVATEKEY = "1";
+            const key = readPrivateKey(filename);
+            expect(typeof key.hidden).toBe("string");
+        });
+    });
+
+    describe("pemToPrivateKey (WebCrypto / browser path)", () => {
+        it("should throw a clear, browser-specific error for an encrypted PEM rather than attempting decryption", async () => {
+            const filename = path.join(tmpDir, "key.pem");
+            await generatePrivateKeyFile(filename, 2048, { passphrase: "some passphrase" });
+            const pem = fs.readFileSync(filename, "utf-8");
+
+            await expect(pemToPrivateKey(pem)).rejects.toThrow(/not supported/i);
+        });
+
+        it("should still work for unencrypted input", async () => {
+            const filename = path.join(tmpDir, "key.pem");
+            await generatePrivateKeyFile(filename, 2048);
+            const pem = fs.readFileSync(filename, "utf-8");
+
+            const cryptoKey = await pemToPrivateKey(pem);
+            expect(cryptoKey).toBeTruthy();
+        });
+    });
+});

--- a/packages/node-opcua-crypto-test/test/test_private_key_permissions.ts
+++ b/packages/node-opcua-crypto-test/test/test_private_key_permissions.ts
@@ -1,0 +1,66 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { generatePrivateKeyFile, generatePrivateKeyFileAlternate } from "node-opcua-crypto";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+const isWin32 = process.platform === "win32";
+const modeBits = (filename: string) => fs.statSync(filename).mode & 0o777;
+
+describe("private key file permissions", () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "node-opcua-crypto-perms-"));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    describe.skipIf(isWin32)("on POSIX", () => {
+        it("generatePrivateKeyFile should create the key with mode 0600", async () => {
+            const filename = path.join(tmpDir, "key1.pem");
+            await generatePrivateKeyFile(filename, 2048);
+            expect(modeBits(filename)).toBe(0o600);
+        });
+
+        it("generatePrivateKeyFile should repair a pre-existing loosely-permissioned file", async () => {
+            const filename = path.join(tmpDir, "key2.pem");
+            fs.writeFileSync(filename, "placeholder", { mode: 0o644 });
+            expect(modeBits(filename)).toBe(0o644);
+
+            await generatePrivateKeyFile(filename, 2048);
+            expect(modeBits(filename)).toBe(0o600);
+        });
+
+        it("generatePrivateKeyFileAlternate should create the key with mode 0600", async () => {
+            const filename = path.join(tmpDir, "key3.pem");
+            await generatePrivateKeyFileAlternate(filename, 2048);
+            expect(modeBits(filename)).toBe(0o600);
+        });
+
+        it("generatePrivateKeyFileAlternate should repair a pre-existing loosely-permissioned file", async () => {
+            const filename = path.join(tmpDir, "key4.pem");
+            fs.writeFileSync(filename, "placeholder", { mode: 0o644 });
+            expect(modeBits(filename)).toBe(0o644);
+
+            await generatePrivateKeyFileAlternate(filename, 2048);
+            expect(modeBits(filename)).toBe(0o600);
+        });
+    });
+
+    describe.skipIf(!isWin32)("on Windows", () => {
+        it("generatePrivateKeyFile should not throw even though permission hardening is a no-op", async () => {
+            const filename = path.join(tmpDir, "key1.pem");
+            await generatePrivateKeyFile(filename, 2048);
+            expect(fs.existsSync(filename)).toBe(true);
+        });
+
+        it("generatePrivateKeyFileAlternate should not throw even though permission hardening is a no-op", async () => {
+            const filename = path.join(tmpDir, "key2.pem");
+            await generatePrivateKeyFileAlternate(filename, 2048);
+            expect(fs.existsSync(filename)).toBe(true);
+        });
+    });
+});

--- a/packages/node-opcua-crypto/source/common.ts
+++ b/packages/node-opcua-crypto/source/common.ts
@@ -28,7 +28,7 @@ export const { createPrivateKey: createPrivateKeyFromNodeJSCrypto } = __crypto;
 
 type KeyFormat = "pem" | "der" | "jwk";
 type KeyObjectType = "secret" | "public" | "private";
-interface KeyExportOptions<T extends KeyFormat> {
+export interface KeyExportOptions<T extends KeyFormat> {
     type: "pkcs1" | "spki" | "pkcs8" | "sec1";
     format: T;
     cipher?: string | undefined;
@@ -52,6 +52,19 @@ export function isKeyObject(mayBeKeyObject: unknown): boolean {
 }
 export type PrivateKey = { hidden: string } | { hidden: KeyObject };
 export type PublicKey = KeyObject;
+
+/**
+ * Thrown when a private key is encrypted (PKCS#8 `ENCRYPTED PRIVATE KEY`)
+ * and the caller did not supply a passphrase to decrypt it. Reading an
+ * encrypted key without a passphrase always fails closed — it never falls
+ * back to treating the key as unencrypted or skipping it.
+ */
+export class PrivateKeyPassphraseRequiredError extends Error {
+    constructor(message = "This private key is encrypted and requires a passphrase to be read") {
+        super(message);
+        this.name = "PrivateKeyPassphraseRequiredError";
+    }
+}
 
 export type Nonce = Buffer;
 export type PEM = string;

--- a/packages/node-opcua-crypto/source/x509/coerce_private_key.ts
+++ b/packages/node-opcua-crypto/source/x509/coerce_private_key.ts
@@ -1,4 +1,10 @@
-import { createPrivateKeyFromNodeJSCrypto, isKeyObject, type KeyObject, type PrivateKey } from "../common.js";
+import {
+    createPrivateKeyFromNodeJSCrypto,
+    isKeyObject,
+    type KeyObject,
+    type PrivateKey,
+    PrivateKeyPassphraseRequiredError,
+} from "../common.js";
 import { getCrypto } from "./_crypto.js";
 import { derToPrivateKey, pemToPrivateKey } from "./create_key_pair.js";
 
@@ -6,9 +12,25 @@ const crypto = getCrypto();
 
 const doDebug = false;
 
-export function coercePEMorDerToPrivateKey(privateKeyInDerOrPem: string | Buffer): PrivateKey {
+const ENCRYPTED_PEM_HEADER = "-----BEGIN ENCRYPTED PRIVATE KEY-----";
+
+/**
+ * @param privateKeyInDerOrPem
+ * @param passphrase — required if the PEM is an encrypted PKCS#8 key
+ *   (`-----BEGIN ENCRYPTED PRIVATE KEY-----`). Throws
+ *   {@link PrivateKeyPassphraseRequiredError} if the key is encrypted and
+ *   no passphrase is supplied. Unencrypted input is unaffected by this
+ *   parameter.
+ */
+export function coercePEMorDerToPrivateKey(privateKeyInDerOrPem: string | Buffer, passphrase?: string | Buffer): PrivateKey {
     if (typeof privateKeyInDerOrPem === "string") {
-        const hidden = createPrivateKeyFromNodeJSCrypto(privateKeyInDerOrPem);
+        if (privateKeyInDerOrPem.includes(ENCRYPTED_PEM_HEADER) && passphrase === undefined) {
+            throw new PrivateKeyPassphraseRequiredError();
+        }
+        const hidden =
+            passphrase !== undefined
+                ? createPrivateKeyFromNodeJSCrypto({ key: privateKeyInDerOrPem, format: "pem", passphrase })
+                : createPrivateKeyFromNodeJSCrypto(privateKeyInDerOrPem);
         return { hidden: hidden as unknown as KeyObject };
     }
     //istanbul ignore next

--- a/packages/node-opcua-crypto/source/x509/create_key_pair.ts
+++ b/packages/node-opcua-crypto/source/x509/create_key_pair.ts
@@ -22,6 +22,8 @@
 // ---------------------------------------------------------------------------------------------------------------------
 import { getCrypto, x509 } from "./_crypto.js";
 
+const ENCRYPTED_PEM_HEADER = "-----BEGIN ENCRYPTED PRIVATE KEY-----";
+
 export async function generateKeyPair(modulusLength: 1024 | 2048 | 3072 | 4096 = 2048): Promise<CryptoKeyPair> {
     const crypto = getCrypto();
 
@@ -79,6 +81,17 @@ export async function derToPrivateKey(privDer: ArrayBuffer): Promise<CryptoKey> 
 }
 
 export async function pemToPrivateKey(pem: string): Promise<CryptoKey> {
+    // WebCrypto's SubtleCrypto.importKey("pkcs8", ...) has no notion of an
+    // encrypted PKCS#8 key, so this path can never decrypt one — fail with a
+    // clear message instead of the confusing DER-parsing error that would
+    // otherwise come from feeding EncryptedPrivateKeyInfo DER to importKey.
+    if (pem.includes(ENCRYPTED_PEM_HEADER)) {
+        throw new Error(
+            "This private key is encrypted (PKCS#8 ENCRYPTED PRIVATE KEY). " +
+                "Encrypted private keys are not supported by the WebCrypto-based browser build; " +
+                "use the Node.js build's readPrivateKey()/readPrivateKeyAsync() with a passphrase instead.",
+        );
+    }
     // https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/importKey
     const privDer = x509.PemConverter.decode(pem);
     return derToPrivateKey(privDer[0]);

--- a/packages/node-opcua-crypto/source_nodejs/generate_private_key_filename.ts
+++ b/packages/node-opcua-crypto/source_nodejs/generate_private_key_filename.ts
@@ -24,10 +24,42 @@
 import { generateKeyPairSync } from "node:crypto";
 import fs from "node:fs";
 import { generateKeyPair, privateKeyToPEM } from "../source/index.js";
-export async function generatePrivateKeyFile(privateKeyFilename: string, modulusLength: 1024 | 2048 | 3072 | 4096) {
+import { restrictPrivateKeyFilePermissions } from "./permissions.js";
+
+export interface GeneratePrivateKeyFileOptions {
+    /** Encrypt the generated key with this passphrase (PKCS#8, aes-256-cbc). Omit to write it unencrypted. */
+    passphrase?: string | Buffer;
+}
+
+export async function generatePrivateKeyFile(
+    privateKeyFilename: string,
+    modulusLength: 1024 | 2048 | 3072 | 4096,
+    options: GeneratePrivateKeyFileOptions = {},
+) {
+    const { passphrase } = options;
+    if (passphrase !== undefined) {
+        // The default path below exports via WebCrypto, which cannot produce
+        // encrypted PKCS#8; use native node:crypto instead, same as
+        // generatePrivateKeyFileAlternate.
+        //
+        // Note: generateKeyPairSync's privateKeyEncoding.passphrase is typed
+        // as `string` only (not `string | Buffer`, unlike createPrivateKey's
+        // passphrase option elsewhere in this file/package), so a Buffer
+        // passphrase is converted here.
+        const passphraseString: string = Buffer.isBuffer(passphrase) ? passphrase.toString("utf-8") : passphrase;
+        const { privateKey } = generateKeyPairSync("rsa", {
+            modulusLength,
+            privateKeyEncoding: { type: "pkcs8", format: "pem", cipher: "aes-256-cbc", passphrase: passphraseString },
+            publicKeyEncoding: { type: "spki", format: "pem" },
+        });
+        await fs.promises.writeFile(privateKeyFilename, privateKey, { encoding: "utf-8", mode: 0o600 });
+        await restrictPrivateKeyFilePermissions(privateKeyFilename);
+        return;
+    }
     const keys = await generateKeyPair(modulusLength);
     const privateKeyPem = await privateKeyToPEM(keys.privateKey);
-    await fs.promises.writeFile(privateKeyFilename, privateKeyPem.privPem, "utf-8");
+    await fs.promises.writeFile(privateKeyFilename, privateKeyPem.privPem, { encoding: "utf-8", mode: 0o600 });
+    await restrictPrivateKeyFilePermissions(privateKeyFilename);
     privateKeyPem.privPem = "";
     privateKeyPem.privDer = new ArrayBuffer(0);
 }
@@ -44,5 +76,6 @@ export async function generatePrivateKeyFileAlternate(privateKeyFilename: string
         privateKeyEncoding: { type: "pkcs8", format: "pem" },
         publicKeyEncoding: { type: "spki", format: "pem" },
     });
-    await fs.promises.writeFile(privateKeyFilename, privateKey, "utf-8");
+    await fs.promises.writeFile(privateKeyFilename, privateKey, { encoding: "utf-8", mode: 0o600 });
+    await restrictPrivateKeyFilePermissions(privateKeyFilename);
 }

--- a/packages/node-opcua-crypto/source_nodejs/permissions.ts
+++ b/packages/node-opcua-crypto/source_nodejs/permissions.ts
@@ -21,9 +21,26 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 // ---------------------------------------------------------------------------------------------------------------------
 
-export * from "./generate_private_key_filename.js";
-export * from "./permissions.js";
-export * from "./read.js";
-export * from "./read_certificate_revocation_list.js";
-export * from "./read_certificate_signing_request.js";
-export * from "./write.js";
+import fs from "node:fs";
+
+/**
+ * Restrict a private key file to owner-only access (mode 0600).
+ *
+ * `fs.chmod` only toggles the read-only attribute on Windows and cannot
+ * express POSIX-style owner-only permissions, so this is a no-op there
+ * rather than a false sense of protection. Errors are logged, not thrown:
+ * a read-only mount or an unexpected ownership mismatch should not prevent
+ * a caller from starting up.
+ */
+export async function restrictPrivateKeyFilePermissions(filename: string): Promise<void> {
+    // istanbul ignore if
+    if (process.platform === "win32") {
+        return;
+    }
+    try {
+        await fs.promises.chmod(filename, 0o600);
+    } catch (err) {
+        // istanbul ignore next
+        console.warn(`could not restrict permissions on ${filename}: ${(err as Error).message}`);
+    }
+}

--- a/packages/node-opcua-crypto/source_nodejs/read.ts
+++ b/packages/node-opcua-crypto/source_nodejs/read.ts
@@ -37,6 +37,7 @@ import type {
     PublicKey,
     PublicKeyPEM,
 } from "../source/common.js";
+import { PrivateKeyPassphraseRequiredError } from "../source/common.js";
 import { split_der } from "../source/crypto_explore_certificate.js";
 import { convertPEMtoDER, identifyPemType, removeTrailingLF, toPem } from "../source/crypto_utils.js";
 
@@ -78,8 +79,8 @@ export function readCertificate(filename: string): Certificate {
     if (count > 1) {
         console.warn(
             `[node-opcua-crypto] readCertificate: "${path.basename(filename)}"` +
-            ` contains ${count} PEM certificate block(s) but only the first` +
-            ` will be used. Use readCertificateChain() to read all certificates.`,
+                ` contains ${count} PEM certificate block(s) but only the first` +
+                ` will be used. Use readCertificateChain() to read all certificates.`,
         );
     }
     return convertPEMtoDER(pem) as Certificate;
@@ -160,8 +161,8 @@ export async function readCertificateAsync(filename: string): Promise<Certificat
     if (count > 1) {
         console.warn(
             `[node-opcua-crypto] readCertificateAsync: "${path.basename(filename)}"` +
-            ` contains ${count} PEM certificate block(s) but only the first` +
-            ` will be used. Use readCertificateChainAsync() to read all certificates.`,
+                ` contains ${count} PEM certificate block(s) but only the first` +
+                ` will be used. Use readCertificateChainAsync() to read all certificates.`,
         );
     }
     return convertPEMtoDER(raw_key) as Certificate;
@@ -193,9 +194,26 @@ export async function readPublicKeyAsync(filename: string): Promise<KeyObject> {
 
 // console.log("createPrivateKey", (crypto as any).createPrivateKey, process.env.NO_CREATE_PRIVATEKEY);
 
-function myCreatePrivateKey(rawKey: string | Buffer): PrivateKey {
+const ENCRYPTED_PEM_HEADER = "-----BEGIN ENCRYPTED PRIVATE KEY-----";
+
+function isEncryptedPem(rawKey: string | Buffer): boolean {
+    return typeof rawKey === "string" && rawKey.includes(ENCRYPTED_PEM_HEADER);
+}
+
+function myCreatePrivateKey(rawKey: string | Buffer, passphrase?: string | Buffer): PrivateKey {
+    const encrypted = isEncryptedPem(rawKey);
+
     if (!createPrivateKey || process.env.NO_CREATE_PRIVATEKEY) {
-        // we are not running nodejs or createPrivateKey is not supported in the environment
+        // we are not running nodejs or createPrivateKey is not supported in the environment:
+        // this fallback path never decrypts anything, so it must fail closed rather than
+        // silently returning the still-encrypted PEM text as if it were usable key material.
+        if (encrypted || passphrase !== undefined) {
+            throw new PrivateKeyPassphraseRequiredError(
+                "This private key is encrypted, and encrypted private keys are not supported " +
+                    "when node:crypto.createPrivateKey is unavailable (NO_CREATE_PRIVATEKEY is set, " +
+                    "or this environment does not provide it).",
+            );
+        }
         if (Buffer.isBuffer(rawKey)) {
             const pemKey = toPem(rawKey, "PRIVATE KEY");
             assert(["RSA PRIVATE KEY", "PRIVATE KEY"].indexOf(identifyPemType(pemKey) as string) >= 0);
@@ -203,10 +221,23 @@ function myCreatePrivateKey(rawKey: string | Buffer): PrivateKey {
         }
         return { hidden: ensureTrailingLF(rawKey as string) };
     }
+
+    if (encrypted && passphrase === undefined) {
+        throw new PrivateKeyPassphraseRequiredError();
+    }
+    if (passphrase !== undefined && Buffer.isBuffer(rawKey)) {
+        // encrypted DER (as opposed to encrypted PEM) is out of scope: this
+        // package only generates/reads encrypted keys in PKCS#8 PEM form.
+        throw new PrivateKeyPassphraseRequiredError("Passphrase-protected DER private keys are not supported; use PEM.");
+    }
+
     // see https://askubuntu.com/questions/1409458/openssl-config-cuases-error-in-node-js-crypto-how-should-the-config-be-updated
     const backup = process.env.OPENSSL_CONF;
     process.env.OPENSSL_CONF = "/dev/null";
-    const retValue = createPrivateKey(rawKey);
+    const retValue =
+        passphrase !== undefined
+            ? createPrivateKey({ key: rawKey as string, format: "pem", passphrase })
+            : createPrivateKey(rawKey);
     process.env.OPENSSL_CONF = backup;
     return { hidden: retValue };
 }
@@ -216,26 +247,32 @@ function ensureTrailingLF(str: string): string {
 }
 /**
  * read a DER or PEM certificate from file
+ *
+ * @param filename
+ * @param passphrase — required if the key is an encrypted PKCS#8 PEM
+ *   (`-----BEGIN ENCRYPTED PRIVATE KEY-----`). Throws
+ *   {@link PrivateKeyPassphraseRequiredError} if the key is encrypted and
+ *   no passphrase is supplied.
  */
-export function readPrivateKey(filename: string): PrivateKey {
+export function readPrivateKey(filename: string, passphrase?: string | Buffer): PrivateKey {
     if (filename.match(/.*\.der/)) {
         const der: Buffer = fs.readFileSync(filename);
-        return myCreatePrivateKey(der);
+        return myCreatePrivateKey(der, passphrase);
     } else {
         const raw_key: string = _readPemFile(filename);
-        return myCreatePrivateKey(raw_key);
+        return myCreatePrivateKey(raw_key, passphrase);
     }
 }
 
 /**
  * Async version of {@link readPrivateKey}.
  */
-export async function readPrivateKeyAsync(filename: string): Promise<PrivateKey> {
+export async function readPrivateKeyAsync(filename: string, passphrase?: string | Buffer): Promise<PrivateKey> {
     const buf = await fs.promises.readFile(filename);
     if (filename.match(/.*\.der/)) {
-        return myCreatePrivateKey(buf);
+        return myCreatePrivateKey(buf, passphrase);
     }
-    return myCreatePrivateKey(removeTrailingLF(buf.toString("utf-8")));
+    return myCreatePrivateKey(removeTrailingLF(buf.toString("utf-8")), passphrase);
 }
 
 export function readCertificatePEM(filename: string): CertificatePEM {

--- a/packages/node-opcua-crypto/source_nodejs/write.ts
+++ b/packages/node-opcua-crypto/source_nodejs/write.ts
@@ -22,10 +22,11 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 import fs from "node:fs";
-
-import type { Certificate } from "../source/common.js";
+import type { Certificate, KeyExportOptions, KeyObject, PrivateKey } from "../source/common.js";
+import { createPrivateKeyFromNodeJSCrypto, isKeyObject } from "../source/common.js";
 import { combine_der } from "../source/crypto_explore_certificate.js";
 import { toPem } from "../source/crypto_utils.js";
+import { restrictPrivateKeyFilePermissions } from "./permissions.js";
 
 // ── PEM ──────────────────────────────────────────────────────
 
@@ -86,4 +87,47 @@ export function writeCertificateChainDer(filename: string, certificates: Certifi
  */
 export async function writeCertificateChainDerAsync(filename: string, certificates: Certificate | Certificate[]): Promise<void> {
     await fs.promises.writeFile(filename, certificatesToDer(certificates));
+}
+
+// ── Private key ──────────────────────────────────────────────
+
+export interface WritePrivateKeyFileOptions {
+    /** Encrypt the key with this passphrase (PKCS#8, aes-256-cbc). Omit to write the key unencrypted. */
+    passphrase?: string | Buffer;
+}
+
+function toExportableKeyObject(privateKey: PrivateKey): KeyObject {
+    const hidden = (privateKey as { hidden: unknown }).hidden;
+    if (isKeyObject(hidden)) {
+        return hidden as KeyObject;
+    }
+    // `hidden` is a raw PEM string (e.g. produced by the createPrivateKey-unavailable
+    // fallback read path) rather than a real KeyObject — turn it into one so it can
+    // be exported/encrypted.
+    return createPrivateKeyFromNodeJSCrypto(hidden as string) as unknown as KeyObject;
+}
+
+/**
+ * Write a private key to disk as PKCS#8 PEM, optionally encrypted with a
+ * passphrase (`aes-256-cbc`). The file is created — and repaired, if it
+ * already existed with looser permissions — with owner-only permissions
+ * (mode 0600 on POSIX; no-op on Windows).
+ *
+ * Node.js only: encrypted PKCS#8 export requires `node:crypto`, which is
+ * not available in the browser build.
+ */
+export async function writePrivateKeyFile(
+    filename: string,
+    privateKey: PrivateKey,
+    options: WritePrivateKeyFileOptions = {},
+): Promise<void> {
+    const { passphrase } = options;
+    const keyObject = toExportableKeyObject(privateKey);
+    const exportOptions: KeyExportOptions<"pem"> =
+        passphrase !== undefined
+            ? { type: "pkcs8", format: "pem", cipher: "aes-256-cbc", passphrase }
+            : { type: "pkcs8", format: "pem" };
+    const pem = keyObject.export(exportOptions) as string;
+    await fs.promises.writeFile(filename, pem, { encoding: "utf-8", mode: 0o600 });
+    await restrictPrivateKeyFilePermissions(filename);
 }


### PR DESCRIPTION
## Summary

Private key files were written as unencrypted PKCS#8 PEM with the process
default file mode, with no way to protect a key with a passphrase. Any
local user or process able to read the directory could read or corrupt
the key; keys captured in a backup or volume snapshot were readable in
clear.

- **File permissions (patch-level, always on):** `generatePrivateKeyFile`
  and `generatePrivateKeyFileAlternate` now write with mode `0600` and
  repair pre-existing looser permissions via a new
  `restrictPrivateKeyFilePermissions()` helper. POSIX only — `fs.chmod`
  only toggles the read-only attribute on Windows and cannot express
  owner-only permissions, so this is a documented no-op there rather than
  a false sense of protection.
- **Passphrase-encrypted keys (minor, opt-in, default off):**
  - `readPrivateKey`/`readPrivateKeyAsync` accept an optional passphrase
    and fail closed with a new `PrivateKeyPassphraseRequiredError` when
    handed an encrypted key with none supplied — including the
    `NO_CREATE_PRIVATEKEY` fallback path, which previously would have
    silently returned the still-encrypted PEM text as if it were usable.
  - A new `writePrivateKeyFile()` writes PKCS#8, encrypted with
    `aes-256-cbc` when a passphrase is given.
  - `generatePrivateKeyFile()` gained a `{ passphrase? }` options
    argument, backward compatible.
  - `coercePEMorDerToPrivateKey()` gained the same optional passphrase.
  - The WebCrypto (browser) path (`pemToPrivateKey`) throws a clear,
    distinct error instead of attempting a decryption it cannot perform.
  - `KeyExportOptions` (previously declared but unused/unexported) is now
    exported and reused for the writer's options.

Encryption stays strictly opt-in and default off: consumers that read
`own/private/private_key.pem` directly (e.g. node-opcua-pki's
`CertificateManager`, and in turn node-opcua's `OPCUAServer`) still expect
plaintext today. A companion node-opcua-pki change adds
`privateKeyPassphrase`/`privateKeyProvider` options to
`CertificateManager` on top of this, once this is released.

## Test plan

- [x] `npm run build` (tsup, ESM+CJS+DTS) — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx biome check` — clean
- [x] Full test suite (`node-opcua-crypto-test`, vitest): 231 passing, 6
      skipped (Windows no-op checks on this run), 0 failing
- [x] Full test suite re-run with `NO_CREATE_PRIVATEKEY=1`: 228 passing, 9
      skipped, 0 failing — confirms the fallback path now fails closed
      instead of silently mis-handling encrypted keys
- [x] New coverage: `test_private_key_permissions.ts` (mode assertions,
      fresh + repair-of-pre-existing-loose-permissions cases, POSIX and
      Windows no-op),  `test_private_key_passphrase.ts` (encrypt/decrypt
      round-trip, wrong/missing passphrase, `NO_CREATE_PRIVATEKEY`
      fallback, browser-path rejection, `coercePEMorDerToPrivateKey`)